### PR TITLE
Fix <pre> overflow

### DIFF
--- a/app/components/content.tsx
+++ b/app/components/content.tsx
@@ -21,7 +21,7 @@ export function Content({ page, disableToc }: ContentProps) {
 
   return (
     <div className="flex items-start">
-      <div ref={contentRef} className="max-w-[720px] lg:pr-12">
+      <div ref={contentRef} className="w-full max-w-[720px] lg:pr-12">
         <RichTextView page={page} />
       </div>
 


### PR DESCRIPTION
Hey guys, first of all, impressive work here! 🎉 

I just noticed that the `pre` tag has `overflow-x: auto` but since its container doesn't define a `width:100%` but just a max-width, it was breaking, so just added this very small fix.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/3991845/155767630-3d008a58-aa1b-4b46-8672-ec67e2346344.png)|![image](https://user-images.githubusercontent.com/3991845/155767673-69f6f9b4-e6e7-4e3d-bf6b-0599413635b7.png)| 