### PR TITLE
fix: preview mode not working properly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # GraphCMS
 GRAPHCMS_ENDPOINT=
-GRAPHCMS_PREVIEW_TOKEN=
+GRAPHCMS_DEV_TOKEN=
+GRAPHCMS_PROD_TOKEN=
 
 # For preview mode
 # Your token needs to match the one in the CMS

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The simplest way to get started is by cloning the GraphCMS project and deploying it to Vercel.
 
-[![Clone project](https://graphcms.com/button)](https://app.graphcms.com/clone/1bc5b8c08db04e629d98dc54d6bfe5e5) [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FGraphCMS%2Fdocs-starter&env=GRAPHCMS_ENDPOINT,GRAPHCMS_PREVIEW_TOKEN,PREVIEW_SECRET&envDescription=The%20Enviroment%20variables%20for%20the%20project&envLink=https%3A%2F%2Fdocs.withheadlesscms.com%2Fgetting-started&demo-title=Documentation%20Starter%20Demo&demo-description=See%20the%20docs%20starter%20in%20action!&demo-url=https%3A%2F%2Fdocs.withheadlesscms.com&demo-image=https%3A%2F%2Fuser-images.githubusercontent.com%2F950181%2F154275008-7284677d-f319-42ce-b88b-b5e11b914645.png)
+[![Clone project](https://graphcms.com/button)](https://app.graphcms.com/clone/1bc5b8c08db04e629d98dc54d6bfe5e5) [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FGraphCMS%2Fdocs-starter&env=GRAPHCMS_ENDPOINT,GRAPHCMS_DEV_TOKEN,PREVIEW_SECRET,GRAPHCMS_PROD_TOKEN&envDescription=The%20Enviroment%20variables%20for%20the%20project&envLink=https%3A%2F%2Fdocs.withheadlesscms.com%2Fgetting-started&demo-title=Documentation%20Starter%20Demo&demo-description=See%20the%20docs%20starter%20in%20action!&demo-url=https%3A%2F%2Fdocs.withheadlesscms.com&demo-image=https%3A%2F%2Fuser-images.githubusercontent.com%2F950181%2F154275008-7284677d-f319-42ce-b88b-b5e11b914645.png)
 
 For the complete getting started guide, check our [documentation](https://docs.withheadlesscms.com/getting-started).
 

--- a/app/components/preview-banner.tsx
+++ b/app/components/preview-banner.tsx
@@ -2,23 +2,20 @@ export function PreviewBanner() {
   return (
     <div className="w-full bg-indigo-600">
       <div className="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
-        <div className="pr-16 sm:px-16 sm:text-center">
-          <p className="font-medium text-white">
-            <span>
-              You&apos;re in <strong>preview mode</strong> (Content served from
-              DRAFT) &mdash;&nbsp;
-            </span>
-            <span className="block sm:ml-2 sm:inline-block">
-              <form action="/api/exit-preview" method="post">
-                <button
-                  type="submit"
-                  className="font-bold text-white underline"
-                >
-                  Exit Preview Mode <span aria-hidden="true">&rarr;</span>
-                </button>
-              </form>
-            </span>
-          </p>
+        <div className="text-center text-sm font-medium text-white sm:text-base">
+          <span>
+            You&apos;re in <strong>preview mode</strong> (Content served from
+            DRAFT) &mdash;&nbsp;
+          </span>
+          <form
+            action="/api/exit-preview"
+            method="post"
+            className="inline-block"
+          >
+            <button type="submit" className="font-bold text-white underline">
+              Exit Preview Mode <span aria-hidden="true">&rarr;</span>
+            </button>
+          </form>
         </div>
       </div>
     </div>

--- a/app/lib/graphcms.server.ts
+++ b/app/lib/graphcms.server.ts
@@ -11,12 +11,11 @@ export function sdk({
 }: {
   preview?: boolean;
 }): ReturnType<typeof getSdk> {
-  if (preview) {
-    graphcms.setHeader(
-      `authorization`,
-      `Bearer ${process.env.GRAPHCMS_PREVIEW_TOKEN}`,
-    );
-  }
+  const API_TOKEN = preview
+    ? process.env.GRAPHCMS_DEV_TOKEN
+    : process.env.GRAPHCMS_PROD_TOKEN;
+
+  graphcms.setHeader(`authorization`, `Bearer ${API_TOKEN}`);
 
   try {
     return getSdk(graphcms);

--- a/app/routes/__docs/$chapter.$slug.tsx
+++ b/app/routes/__docs/$chapter.$slug.tsx
@@ -33,8 +33,8 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   const { chapter, slug } = params;
 
   const isInPreview = await isPreviewMode(request);
-  const { GetPage } = await sdk({ preview: isInPreview });
 
+  const { GetPage } = await sdk({ preview: isInPreview });
   const { page } = await GetPage({
     slug: slug as string,
   });

--- a/app/routes/__docs/$slug.tsx
+++ b/app/routes/__docs/$slug.tsx
@@ -45,7 +45,6 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   const { GetPage, GetFirstPageFromChapter } = await sdk({
     preview: isInPreview,
   });
-
   const { page } = await GetPage({
     slug: slug as string,
   });

--- a/app/routes/__docs/index.tsx
+++ b/app/routes/__docs/index.tsx
@@ -54,10 +54,10 @@ export const meta: MetaFunction = ({ data }: MetaFunctionData) => {
 
 export const loader: LoaderFunction = async ({ request }) => {
   const isInPreview = await isPreviewMode(request);
+
   const { GetPage } = await sdk({
     preview: isInPreview,
   });
-
   const { page } = await GetPage({
     slug: 'homepage',
   });

--- a/app/routes/api/exit-preview.ts
+++ b/app/routes/api/exit-preview.ts
@@ -10,7 +10,7 @@ export const loader: LoaderFunction = async () => {
 
 export const action: ActionFunction = async ({ request }) => {
   const cookie = await parseCookie(request, previewModeCookie);
-  cookie.preview = false;
+  cookie.mode = 'normal';
 
   return redirect(`/`, {
     headers: {

--- a/app/routes/api/exit-preview.ts
+++ b/app/routes/api/exit-preview.ts
@@ -10,7 +10,7 @@ export const loader: LoaderFunction = async () => {
 
 export const action: ActionFunction = async ({ request }) => {
   const cookie = await parseCookie(request, previewModeCookie);
-  cookie.mode = 'normal';
+  cookie.stage = 'published';
 
   return redirect(`/`, {
     headers: {

--- a/app/routes/api/preview.ts
+++ b/app/routes/api/preview.ts
@@ -28,7 +28,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   // Enable preview by setting a cookie
   const cookie = await parseCookie(request, previewModeCookie);
-  cookie.mode = 'preview';
+  cookie.stage = 'draft';
 
   return redirect(`/${page.slug}`, {
     headers: {

--- a/app/routes/api/preview.ts
+++ b/app/routes/api/preview.ts
@@ -28,7 +28,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   // Enable preview by setting a cookie
   const cookie = await parseCookie(request, previewModeCookie);
-  cookie.preview = true;
+  cookie.mode = 'preview';
 
   return redirect(`/${page.slug}`, {
     headers: {

--- a/app/utils/preview-mode.server.ts
+++ b/app/utils/preview-mode.server.ts
@@ -1,15 +1,16 @@
 import { createCookie } from 'remix';
 import { parseCookie } from './parse-cookie.server';
 
-export const previewModeCookie = createCookie('preview-mode', {
+export const previewModeCookie = createCookie('mode', {
   path: '/',
   sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
   secure: process.env.NODE_ENV !== 'development',
   httpOnly: true,
+  secrets: [process.env.PREVIEW_SECRET as string],
 });
 
 export async function isPreviewMode(request: Request) {
   const cookie = await parseCookie(request, previewModeCookie);
 
-  return cookie.preview;
+  return cookie?.mode === 'preview';
 }

--- a/app/utils/preview-mode.server.ts
+++ b/app/utils/preview-mode.server.ts
@@ -1,7 +1,8 @@
 import { createCookie } from 'remix';
-import { parseCookie } from './parse-cookie.server';
 
-export const previewModeCookie = createCookie('mode', {
+import { parseCookie } from '~/utils/parse-cookie.server';
+
+export const previewModeCookie = createCookie('stage', {
   path: '/',
   sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
   secure: process.env.NODE_ENV !== 'development',
@@ -12,5 +13,5 @@ export const previewModeCookie = createCookie('mode', {
 export async function isPreviewMode(request: Request) {
   const cookie = await parseCookie(request, previewModeCookie);
 
-  return cookie?.mode === 'preview';
+  return cookie?.stage === 'draft';
 }


### PR DESCRIPTION
There's an issue with preview mode on production only, which this PR aims to fix.

https://user-images.githubusercontent.com/26466516/162209174-0d4b0cdf-5cb6-4130-ad84-952ae6316507.mp4

---

The problem was that the authorization header was being set on preview, and after leaving preview mode, it was still being used. 